### PR TITLE
Moved definition of lastSymbol

### DIFF
--- a/src/symbol_table.c
+++ b/src/symbol_table.c
@@ -9,7 +9,7 @@
 symbol *table[LENGTH];
 
 int literalCount = 0;
-
+char *lastSymbol;
 
 
 void updateLastSymbol(char *varName)

--- a/src/symbol_table.h
+++ b/src/symbol_table.h
@@ -30,7 +30,7 @@ typedef struct symbol
 }symbol;
 
 
-char *lastSymbol;
+extern char *lastSymbol;
 
 void initializeTable(void);
 symbol *addSymbol(char *, int, void *);


### PR DESCRIPTION
Had a compiling problem with the definition of lastSymbol in the .h file. moved it to symbol_table.c and referenced as external in the .h to be able to compile it